### PR TITLE
Add grunt dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
     "watch": "watch 'npm run dev'"
   },
   "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-jshint": "^0.11.2",
+    "grunt-exec": "^0.4.6",
     "jshint": "latest",
+    "load-grunt-tasks": "^3.1.0",
     "node-sass": "^2.0.1"
   },
   "jspm": {


### PR DESCRIPTION
@humancompanion, `grunt build` didn't work for me after cloning and running `npm install` 

I added the following to `package.json` to get `grunt build` to work for me.