### PR TITLE
Add browser sync so Chrome can be used to test out of the box

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
     "pretest": "npm run lint",
     "sass": "node-sass sass/blocks-viewer.scss dist/css/blocks-viewer.css",
     "dev": "npm run lint && npm run sass",
-    "watch": "watch 'npm run dev'"
+    "watch": "watch 'npm run dev'",
+    "start-browser-sync": "browser-sync start --server --files 'test/**, test/*.html, *.html' --startPath 'dev.html' --index 'dev.html'",
+    "start": "npm run start-browser-sync"
   },
   "devDependencies": {
+    "browser-sync": "^2.7.0",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-exec": "^0.4.6",


### PR DESCRIPTION
@humancompanion, here's another, adding browser-sync so I don't have to run Chrome with special flags to run the tests.